### PR TITLE
Notebook demonstrating the InfluxDB HTTP API

### DIFF
--- a/example/example_http_api.ipynb
+++ b/example/example_http_api.ipynb
@@ -1,0 +1,132 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sending SQuaSH data to InfluxDB\n",
+    "\n",
+    "In this example notebook we will sync the SQuaSH production data with our InfluxDB instance, so that we can visualize SQuaSH metrics using [Chronograf](https://chronograf-demo.lsst.codes/). See also [this notebook](https://github.com/lsst-sqre/influx-demo) for a quick introduction on InfluxDB concepts.\n",
+    "\n",
+    "We are using the [InfluxDB HTTP API](https://docs.influxdata.com/influxdb/v1.6/tools/api/) for sending the data. The [InfluxDB python client](https://github.com/influxdata/influxdb-python) would also be an option."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SQUASH_API_URL = \"https://squash-restful-api.lsst.codes/\"\n",
+    "INFLUXDB_API_URL = \"https://influxdb-demo.lsst.codes\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by creating a new database. Note that if the database already exists nothing is done (the existing data is preserved), and an status code 200 (OK) is returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "\n",
+    "DB = \"squash-prod\"\n",
+    "\n",
+    "params={'q': 'CREATE DATABASE \"{}\"'.format(DB)}\n",
+    "r = requests.post(url=INFLUXDB_URL + \"/query\", params=params)\n",
+    "r.status_code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we get a list of existing verification jobs from the SQuaSH API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jobs = requests.get(SQUASH_API_URL + \"/jobs\").json()\n",
+    "print(\"Loading {} verification jobs from SQuaSH...\".format(len(jobs['ids'])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following cell will actually grab the SQuaSH data and write it in the format used by InfluxDB (called [line protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/)):\n",
+    "\n",
+    "\n",
+    "```#<measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]```\n",
+    "\n",
+    "the important thing here is that a mesurement is equivalent to a \"table\" in the database, tags are annotations that are used to query the data, and thus are indexed. Fields correspond to the actual values, and the timestamp acts like the \"primary key\" in a time series database.\n",
+    "\n",
+    "As you run this notebook you might follow the data ingestion using the [Data Explorer](https://chronograf-demo.lsst.codes/sources/2/chronograf/data-explorer) tool in Chronograf."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytz import UTC\n",
+    "from datetime import datetime\n",
+    "from dateutil.parser import parse\n",
+    "\n",
+    "EPOCH = UTC.localize(datetime.utcfromtimestamp(0))\n",
+    "\n",
+    "params = {'db': DB}\n",
+    "\n",
+    "for job_id in jobs['ids']:\n",
+    "    \n",
+    "    r = requests.get(SQUASH_API_URL + \"/job/{}\".format(job_id)).json()\n",
+    "\n",
+    "    # Skip datasets we don't want \n",
+    "    if r['ci_dataset'] == 'unknown' or r['ci_dataset'] == 'decam':\n",
+    "        continue\n",
+    "\n",
+    "    print('Sending line for job {}...'.format(job_id))\n",
+    "\n",
+    "    for meas in r['measurements']:\n",
+    "\n",
+    "        measurement = meas['metric'].split('.')[0]\n",
+    "\n",
+    "        # a tag value cannot have space in them\n",
+    "        tags =  \"filter_name={},dataset={}\".format(r['meta']['filter_name'], r['ci_dataset'].replace(\" \", \"_\"))\n",
+    "\n",
+    "        fields = \"{}={}\".format(meas['metric'], meas['value'])\n",
+    "\n",
+    "        timestamp = int((parse(r['date_created']) - EPOCH).total_seconds()*1e9)\n",
+    "\n",
+    "        line = \"{},{} {} {}\".format(measurement, tags, fields, timestamp)\n",
+    "\n",
+    "        print(line)\n",
+    "        post = requests.post(url=INFLUXDB_URL + \"/write\", params=params, data=line)\n",
+    "\n",
+    "        print(post.status_code)\n",
+    "        print(post.text)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Added example notebook that grab data from SQuaSH and send to InfluxDB so that we can visualize SQuaSH metrics using https://chronograf-demo.lsst.codes