### PR TITLE
Added initial dashboard for validate_drp

### DIFF
--- a/dashboards/validate_drp.json
+++ b/dashboards/validate_drp.json
@@ -1,0 +1,621 @@
+{
+	"meta": {
+		"chronografVersion": "201810242049~nightly",
+		"sources": {
+			"2": {
+				"name": "SQuaSH",
+				"link": "/chronograf/v1/sources/2"
+			}
+		}
+	},
+	"dashboard": {
+		"id": 5,
+		"cells": [
+			{
+				"i": "2adf0a27-6b9e-4e6b-a115-1b5f741d4861",
+				"x": 0,
+				"y": 4,
+				"w": 12,
+				"h": 2,
+				"name": "Astrometry",
+				"queries": [
+					{
+						"query": "SELECT \"validate_drp.AM2\" as \"AM2\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+						"queryConfig": {
+							"database": "",
+							"measurement": "",
+							"retentionPolicy": "",
+							"fields": [],
+							"tags": {},
+							"groupBy": {
+								"time": "",
+								"tags": []
+							},
+							"areTagsAccepted": false,
+							"rawText": "SELECT \"validate_drp.AM2\" as \"AM2\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+							"range": null,
+							"shifts": null
+						},
+						"source": "/chronograf/v1/sources/2",
+						"type": "influxql"
+					}
+				],
+				"axes": {
+					"x": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "AM2",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y2": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					}
+				},
+				"type": "line",
+				"colors": [
+					{
+						"id": "32ed943e-08ce-4567-83df-5668617327bf",
+						"type": "scale",
+						"hex": "#31C0F6",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "949217cd-2c38-47eb-94d1-087b5c35d06d",
+						"type": "scale",
+						"hex": "#A500A5",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "9ab6b7b4-49d8-4d78-9d6b-d52fbb4adeda",
+						"type": "scale",
+						"hex": "#FF7E27",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					}
+				],
+				"legend": {
+					"type": "static",
+					"orientation": "bottom"
+				},
+				"tableOptions": {
+					"verticalTimeAxis": true,
+					"sortBy": {
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					},
+					"wrapping": "truncate",
+					"fixFirstColumn": true
+				},
+				"fieldOptions": [
+					{
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					}
+				],
+				"timeFormat": "MM/DD/YYYY HH:mm:ss",
+				"decimalPlaces": {
+					"isEnforced": true,
+					"digits": 2
+				},
+				"note": "My awesome time series plot showing AM2 metric. You can select a different dataset from the selection widget above. In Chronograf 1.7 I can add these notes describing the plots...\n",
+				"noteVisibility": "default",
+				"links": {
+					"self": "/chronograf/v1/dashboards/5/cells/2adf0a27-6b9e-4e6b-a115-1b5f741d4861"
+				}
+			},
+			{
+				"i": "cb4ef303-e150-4b15-8d1d-8481e4b8069d",
+				"x": 0,
+				"y": 0,
+				"w": 12,
+				"h": 2,
+				"name": "Introduction",
+				"queries": [
+					{
+						"query": "",
+						"queryConfig": {
+							"database": "",
+							"measurement": "",
+							"retentionPolicy": "",
+							"fields": [],
+							"tags": {},
+							"groupBy": {
+								"time": "",
+								"tags": []
+							},
+							"areTagsAccepted": false,
+							"rawText": "",
+							"range": null,
+							"shifts": null
+						},
+						"source": "/chronograf/v1/sources/2",
+						"type": "influxql"
+					}
+				],
+				"axes": {
+					"x": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "AM1",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y2": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					}
+				},
+				"type": "note",
+				"colors": [],
+				"legend": {},
+				"tableOptions": {
+					"verticalTimeAxis": true,
+					"sortBy": {
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					},
+					"wrapping": "truncate",
+					"fixFirstColumn": true
+				},
+				"fieldOptions": [
+					{
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					}
+				],
+				"timeFormat": "MM/DD/YYYY HH:mm:ss",
+				"decimalPlaces": {
+					"isEnforced": true,
+					"digits": 2
+				},
+				"note": "## My awesome dashboard showing validate_drp metrics\n\nIn Chronograf 1.7 you can have cells like this one with HTML or Markdown content. With this mechanism we can also embed other contents from our APIs...\n",
+				"noteVisibility": "showWhenNoData",
+				"links": {
+					"self": "/chronograf/v1/dashboards/5/cells/cb4ef303-e150-4b15-8d1d-8481e4b8069d"
+				}
+			},
+			{
+				"i": "dcacbe3c-3faf-49fa-864f-3c8667f62799",
+				"x": 0,
+				"y": 8,
+				"w": 12,
+				"h": 3,
+				"name": "Table view ",
+				"queries": [
+					{
+						"query": "SELECT \"validate_drp.AM1\" as \"AM1\", \"validate_drp.AM2\" as \"AM2\", \"validate_drp.PA1\" as \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > '2016-10-18T20:49:00.000Z' AND time < '2018-10-18T20:49:00.000Z' AND \"dataset\"='validation_data_hsc' AND \"filter_name\"='HSC-I'",
+						"queryConfig": {
+							"database": "",
+							"measurement": "",
+							"retentionPolicy": "",
+							"fields": [],
+							"tags": {},
+							"groupBy": {
+								"time": "",
+								"tags": []
+							},
+							"areTagsAccepted": false,
+							"rawText": "SELECT \"validate_drp.AM1\" as \"AM1\", \"validate_drp.AM2\" as \"AM2\", \"validate_drp.PA1\" as \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > '2016-10-18T20:49:00.000Z' AND time < '2018-10-18T20:49:00.000Z' AND \"dataset\"='validation_data_hsc' AND \"filter_name\"='HSC-I'",
+							"range": null,
+							"shifts": null
+						},
+						"source": "/chronograf/v1/sources/2",
+						"type": "influxql"
+					}
+				],
+				"axes": {
+					"x": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y2": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					}
+				},
+				"type": "table",
+				"colors": [
+					{
+						"id": "base",
+						"type": "text",
+						"hex": "#00C9FF",
+						"name": "laser",
+						"value": "-1000000000000000000"
+					}
+				],
+				"legend": {},
+				"tableOptions": {
+					"verticalTimeAxis": true,
+					"sortBy": {
+						"internalName": "time",
+						"displayName": "Time (UTC)",
+						"visible": true
+					},
+					"wrapping": "truncate",
+					"fixFirstColumn": true
+				},
+				"fieldOptions": [
+					{
+						"internalName": "time",
+						"displayName": "Time (UTC)",
+						"visible": true
+					},
+					{
+						"internalName": "validate_drp.AM1",
+						"displayName": "AM1",
+						"visible": true
+					},
+					{
+						"internalName": "validate_drp.AM2",
+						"displayName": "AM2",
+						"visible": true
+					},
+					{
+						"internalName": "validate_drp.PA1",
+						"displayName": "PA1",
+						"visible": true
+					}
+				],
+				"timeFormat": "MM/DD/YYYY HH:mm:ss",
+				"decimalPlaces": {
+					"isEnforced": true,
+					"digits": 4
+				},
+				"note": "",
+				"noteVisibility": "default",
+				"links": {
+					"self": "/chronograf/v1/dashboards/5/cells/dcacbe3c-3faf-49fa-864f-3c8667f62799"
+				}
+			},
+			{
+				"i": "0c0b336b-d9e2-47e4-8c2f-ea79b062307f",
+				"x": 0,
+				"y": 6,
+				"w": 12,
+				"h": 2,
+				"name": "Photometry",
+				"queries": [
+					{
+						"query": "SELECT \"validate_drp.PA1\" AS \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
+						"queryConfig": {
+							"database": "",
+							"measurement": "",
+							"retentionPolicy": "",
+							"fields": [],
+							"tags": {},
+							"groupBy": {
+								"time": "",
+								"tags": []
+							},
+							"areTagsAccepted": false,
+							"rawText": "SELECT \"validate_drp.PA1\" AS \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
+							"range": null,
+							"shifts": null
+						},
+						"source": "/chronograf/v1/sources/2",
+						"type": "influxql"
+					}
+				],
+				"axes": {
+					"x": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "PA1",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y2": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					}
+				},
+				"type": "line",
+				"colors": [
+					{
+						"id": "32ed943e-08ce-4567-83df-5668617327bf",
+						"type": "scale",
+						"hex": "#31C0F6",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "949217cd-2c38-47eb-94d1-087b5c35d06d",
+						"type": "scale",
+						"hex": "#A500A5",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "9ab6b7b4-49d8-4d78-9d6b-d52fbb4adeda",
+						"type": "scale",
+						"hex": "#FF7E27",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					}
+				],
+				"legend": {
+					"type": "static",
+					"orientation": "bottom"
+				},
+				"tableOptions": {
+					"verticalTimeAxis": true,
+					"sortBy": {
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					},
+					"wrapping": "truncate",
+					"fixFirstColumn": true
+				},
+				"fieldOptions": [
+					{
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					}
+				],
+				"timeFormat": "MM/DD/YYYY HH:mm:ss",
+				"decimalPlaces": {
+					"isEnforced": true,
+					"digits": 2
+				},
+				"note": "",
+				"noteVisibility": "default",
+				"links": {
+					"self": "/chronograf/v1/dashboards/5/cells/0c0b336b-d9e2-47e4-8c2f-ea79b062307f"
+				}
+			},
+			{
+				"i": "f14983cf-d803-4400-99e3-e691cce6936c",
+				"x": 0,
+				"y": 2,
+				"w": 12,
+				"h": 2,
+				"name": "Astrometry",
+				"queries": [
+					{
+						"query": "SELECT \"validate_drp.AM1\" as \"AM1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+						"queryConfig": {
+							"database": "",
+							"measurement": "",
+							"retentionPolicy": "",
+							"fields": [],
+							"tags": {},
+							"groupBy": {
+								"time": "",
+								"tags": []
+							},
+							"areTagsAccepted": false,
+							"rawText": "SELECT \"validate_drp.AM1\" as \"AM1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+							"range": null,
+							"shifts": null
+						},
+						"source": "/chronograf/v1/sources/2",
+						"type": "influxql"
+					}
+				],
+				"axes": {
+					"x": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "AM1",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y2": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					}
+				},
+				"type": "line",
+				"colors": [
+					{
+						"id": "32ed943e-08ce-4567-83df-5668617327bf",
+						"type": "scale",
+						"hex": "#31C0F6",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "949217cd-2c38-47eb-94d1-087b5c35d06d",
+						"type": "scale",
+						"hex": "#A500A5",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "9ab6b7b4-49d8-4d78-9d6b-d52fbb4adeda",
+						"type": "scale",
+						"hex": "#FF7E27",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					}
+				],
+				"legend": {
+					"type": "static",
+					"orientation": "bottom"
+				},
+				"tableOptions": {
+					"verticalTimeAxis": true,
+					"sortBy": {
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					},
+					"wrapping": "truncate",
+					"fixFirstColumn": true
+				},
+				"fieldOptions": [
+					{
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					}
+				],
+				"timeFormat": "MM/DD/YYYY HH:mm:ss",
+				"decimalPlaces": {
+					"isEnforced": true,
+					"digits": 2
+				},
+				"note": "My awesome time series plot showing AM1 metric. You can select a different dataset from the selection widget above. In Chronograf 1.7 I can add these notes describing the plots...\n",
+				"noteVisibility": "default",
+				"links": {
+					"self": "/chronograf/v1/dashboards/5/cells/f14983cf-d803-4400-99e3-e691cce6936c"
+				}
+			}
+		],
+		"templates": [
+			{
+				"tempVar": ":Dataset:",
+				"values": [
+					{
+						"value": "validation_data_hsc",
+						"type": "tagValue",
+						"selected": true
+					}
+				],
+				"id": "2d2d36ce-21ef-48fc-a0c1-4b954512f9a5",
+				"type": "tagValues",
+				"label": "",
+				"query": {
+					"influxql": "SHOW TAG VALUES ON :database: FROM :measurement: WITH KEY=:tagKey:",
+					"db": "squash-prod",
+					"measurement": "validate_drp",
+					"tagKey": "dataset",
+					"fieldKey": ""
+				},
+				"links": {
+					"self": "/chronograf/v1/dashboards/5/templates/2d2d36ce-21ef-48fc-a0c1-4b954512f9a5"
+				}
+			}
+		],
+		"name": "validate_drp",
+		"organization": "default",
+		"links": {
+			"self": "/chronograf/v1/dashboards/5",
+			"cells": "/chronograf/v1/dashboards/5/cells",
+			"templates": "/chronograf/v1/dashboards/5/templates"
+		}
+	}
+}

--- a/dashboards/validate_drp.json
+++ b/dashboards/validate_drp.json
@@ -1,6 +1,6 @@
 {
 	"meta": {
-		"chronografVersion": "201810242049~nightly",
+		"chronografVersion": "1.7.0",
 		"sources": {
 			"2": {
 				"name": "SQuaSH",
@@ -9,18 +9,18 @@
 		}
 	},
 	"dashboard": {
-		"id": 5,
+		"id": 2,
 		"cells": [
 			{
-				"i": "2adf0a27-6b9e-4e6b-a115-1b5f741d4861",
-				"x": 0,
+				"i": "31a8fc8f-ee23-41a1-b349-b7e29abcf1ee",
+				"x": 6,
 				"y": 4,
-				"w": 12,
+				"w": 6,
 				"h": 2,
-				"name": "Astrometry",
+				"name": "Image Quality",
 				"queries": [
 					{
-						"query": "SELECT \"validate_drp.AM2\" as \"AM2\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+						"query": "SELECT \"validate_drp.TE1\" AS \"TE1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
 						"queryConfig": {
 							"database": "",
 							"measurement": "",
@@ -32,7 +32,127 @@
 								"tags": []
 							},
 							"areTagsAccepted": false,
-							"rawText": "SELECT \"validate_drp.AM2\" as \"AM2\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+							"rawText": "SELECT \"validate_drp.TE1\" AS \"TE1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
+							"range": null,
+							"shifts": null
+						},
+						"source": "/chronograf/v1/sources/2",
+						"type": "influxql"
+					}
+				],
+				"axes": {
+					"x": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "TE1",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					},
+					"y2": {
+						"bounds": [
+							"",
+							""
+						],
+						"label": "",
+						"prefix": "",
+						"suffix": "",
+						"base": "10",
+						"scale": "linear"
+					}
+				},
+				"type": "line",
+				"colors": [
+					{
+						"id": "32ed943e-08ce-4567-83df-5668617327bf",
+						"type": "scale",
+						"hex": "#31C0F6",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "949217cd-2c38-47eb-94d1-087b5c35d06d",
+						"type": "scale",
+						"hex": "#A500A5",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					},
+					{
+						"id": "9ab6b7b4-49d8-4d78-9d6b-d52fbb4adeda",
+						"type": "scale",
+						"hex": "#FF7E27",
+						"name": "Nineteen Eighty Four",
+						"value": "0"
+					}
+				],
+				"legend": {
+					"type": "static",
+					"orientation": "bottom"
+				},
+				"tableOptions": {
+					"verticalTimeAxis": true,
+					"sortBy": {
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					},
+					"wrapping": "truncate",
+					"fixFirstColumn": true
+				},
+				"fieldOptions": [
+					{
+						"internalName": "time",
+						"displayName": "",
+						"visible": true
+					}
+				],
+				"timeFormat": "MM/DD/YYYY HH:mm:ss",
+				"decimalPlaces": {
+					"isEnforced": true,
+					"digits": 2
+				},
+				"note": "",
+				"noteVisibility": "default",
+				"links": {
+					"self": "/chronograf/v1/dashboards/2/cells/31a8fc8f-ee23-41a1-b349-b7e29abcf1ee"
+				}
+			},
+			{
+				"i": "2b83b19e-850b-4838-b943-2a995721f868",
+				"x": 6,
+				"y": 2,
+				"w": 6,
+				"h": 2,
+				"name": "Astrometry",
+				"queries": [
+					{
+						"query": "SELECT \"validate_drp.AM2\" as \"AM2\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+						"queryConfig": {
+							"database": "",
+							"measurement": "",
+							"retentionPolicy": "",
+							"fields": [],
+							"tags": {},
+							"groupBy": {
+								"time": "",
+								"tags": []
+							},
+							"areTagsAccepted": false,
+							"rawText": "SELECT \"validate_drp.AM2\" as \"AM2\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
 							"range": null,
 							"shifts": null
 						},
@@ -125,14 +245,14 @@
 					"isEnforced": true,
 					"digits": 2
 				},
-				"note": "My awesome time series plot showing AM2 metric. You can select a different dataset from the selection widget above. In Chronograf 1.7 I can add these notes describing the plots...\n",
+				"note": "",
 				"noteVisibility": "default",
 				"links": {
-					"self": "/chronograf/v1/dashboards/5/cells/2adf0a27-6b9e-4e6b-a115-1b5f741d4861"
+					"self": "/chronograf/v1/dashboards/2/cells/2b83b19e-850b-4838-b943-2a995721f868"
 				}
 			},
 			{
-				"i": "cb4ef303-e150-4b15-8d1d-8481e4b8069d",
+				"i": "c5d67ca4-ce35-4afa-b670-94b899e260a5",
 				"x": 0,
 				"y": 0,
 				"w": 12,
@@ -220,22 +340,22 @@
 					"isEnforced": true,
 					"digits": 2
 				},
-				"note": "## My awesome dashboard showing validate_drp metrics\n\nIn Chronograf 1.7 you can have cells like this one with HTML or Markdown content. With this mechanism we can also embed other contents from our APIs...\n",
+				"note": "## Data Release Processing metrics\n\nData presented here is from nightly runs of [validate_drp](https://ci.lsst.codes/blue/organizations/jenkins/sqre%2Fvalidate_drp/activity).\n",
 				"noteVisibility": "showWhenNoData",
 				"links": {
-					"self": "/chronograf/v1/dashboards/5/cells/cb4ef303-e150-4b15-8d1d-8481e4b8069d"
+					"self": "/chronograf/v1/dashboards/2/cells/c5d67ca4-ce35-4afa-b670-94b899e260a5"
 				}
 			},
 			{
-				"i": "dcacbe3c-3faf-49fa-864f-3c8667f62799",
+				"i": "d8e50598-f11b-4f88-80a4-4927bcc95727",
 				"x": 0,
-				"y": 8,
+				"y": 6,
 				"w": 12,
-				"h": 3,
+				"h": 5,
 				"name": "Table view ",
 				"queries": [
 					{
-						"query": "SELECT \"validate_drp.AM1\" as \"AM1\", \"validate_drp.AM2\" as \"AM2\", \"validate_drp.PA1\" as \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > '2016-10-18T20:49:00.000Z' AND time < '2018-10-18T20:49:00.000Z' AND \"dataset\"='validation_data_hsc' AND \"filter_name\"='HSC-I'",
+						"query": "SELECT \"validate_drp.AM1\" AS \"AM1\", \"validate_drp.AM2\" AS \"AM2\", \"validate_drp.PA1\" AS \"PA1\", \"validate_drp.TE1\" AS \"TE1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset:",
 						"queryConfig": {
 							"database": "",
 							"measurement": "",
@@ -247,7 +367,7 @@
 								"tags": []
 							},
 							"areTagsAccepted": false,
-							"rawText": "SELECT \"validate_drp.AM1\" as \"AM1\", \"validate_drp.AM2\" as \"AM2\", \"validate_drp.PA1\" as \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > '2016-10-18T20:49:00.000Z' AND time < '2018-10-18T20:49:00.000Z' AND \"dataset\"='validation_data_hsc' AND \"filter_name\"='HSC-I'",
+							"rawText": "SELECT \"validate_drp.AM1\" AS \"AM1\", \"validate_drp.AM2\" AS \"AM2\", \"validate_drp.PA1\" AS \"PA1\", \"validate_drp.TE1\" AS \"TE1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset:",
 							"range": null,
 							"shifts": null
 						},
@@ -319,17 +439,22 @@
 					},
 					{
 						"internalName": "validate_drp.AM1",
-						"displayName": "AM1",
+						"displayName": "",
 						"visible": true
 					},
 					{
 						"internalName": "validate_drp.AM2",
-						"displayName": "AM2",
+						"displayName": "",
 						"visible": true
 					},
 					{
 						"internalName": "validate_drp.PA1",
-						"displayName": "PA1",
+						"displayName": "",
+						"visible": true
+					},
+					{
+						"internalName": "validate_drp.TE1",
+						"displayName": "",
 						"visible": true
 					}
 				],
@@ -341,19 +466,19 @@
 				"note": "",
 				"noteVisibility": "default",
 				"links": {
-					"self": "/chronograf/v1/dashboards/5/cells/dcacbe3c-3faf-49fa-864f-3c8667f62799"
+					"self": "/chronograf/v1/dashboards/2/cells/d8e50598-f11b-4f88-80a4-4927bcc95727"
 				}
 			},
 			{
-				"i": "0c0b336b-d9e2-47e4-8c2f-ea79b062307f",
+				"i": "c1293d1e-833f-49dc-acba-cf573699cc29",
 				"x": 0,
-				"y": 6,
-				"w": 12,
+				"y": 4,
+				"w": 6,
 				"h": 2,
 				"name": "Photometry",
 				"queries": [
 					{
-						"query": "SELECT \"validate_drp.PA1\" AS \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
+						"query": "SELECT \"validate_drp.PA1\" AS \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
 						"queryConfig": {
 							"database": "",
 							"measurement": "",
@@ -365,7 +490,7 @@
 								"tags": []
 							},
 							"areTagsAccepted": false,
-							"rawText": "SELECT \"validate_drp.PA1\" AS \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
+							"rawText": "SELECT \"validate_drp.PA1\" AS \"PA1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
 							"range": null,
 							"shifts": null
 						},
@@ -461,19 +586,19 @@
 				"note": "",
 				"noteVisibility": "default",
 				"links": {
-					"self": "/chronograf/v1/dashboards/5/cells/0c0b336b-d9e2-47e4-8c2f-ea79b062307f"
+					"self": "/chronograf/v1/dashboards/2/cells/c1293d1e-833f-49dc-acba-cf573699cc29"
 				}
 			},
 			{
-				"i": "f14983cf-d803-4400-99e3-e691cce6936c",
+				"i": "7df11386-dd4f-4bd4-8b2d-1b1f93f8dc7f",
 				"x": 0,
 				"y": 2,
-				"w": 12,
+				"w": 6,
 				"h": 2,
 				"name": "Astrometry",
 				"queries": [
 					{
-						"query": "SELECT \"validate_drp.AM1\" as \"AM1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+						"query": "SELECT \"validate_drp.AM1\" AS \"AM1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
 						"queryConfig": {
 							"database": "",
 							"measurement": "",
@@ -485,7 +610,7 @@
 								"tags": []
 							},
 							"areTagsAccepted": false,
-							"rawText": "SELECT \"validate_drp.AM1\" as \"AM1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"dataset\"=:Dataset: GROUP BY  \"filter_name\" FILL(null)",
+							"rawText": "SELECT \"validate_drp.AM1\" AS \"AM1\" FROM \"squash-prod\".\"autogen\".\"validate_drp\" WHERE time > :dashboardTime: AND \"filter_name\"=':Filter:' AND \"ci_dataset\"=:Dataset: GROUP BY \"filter_name\" FILL(null)",
 							"range": null,
 							"shifts": null
 						},
@@ -578,10 +703,10 @@
 					"isEnforced": true,
 					"digits": 2
 				},
-				"note": "My awesome time series plot showing AM1 metric. You can select a different dataset from the selection widget above. In Chronograf 1.7 I can add these notes describing the plots...\n",
+				"note": "",
 				"noteVisibility": "default",
 				"links": {
-					"self": "/chronograf/v1/dashboards/5/cells/f14983cf-d803-4400-99e3-e691cce6936c"
+					"self": "/chronograf/v1/dashboards/2/cells/7df11386-dd4f-4bd4-8b2d-1b1f93f8dc7f"
 				}
 			}
 		],
@@ -602,20 +727,42 @@
 					"influxql": "SHOW TAG VALUES ON :database: FROM :measurement: WITH KEY=:tagKey:",
 					"db": "squash-prod",
 					"measurement": "validate_drp",
-					"tagKey": "dataset",
+					"tagKey": "ci_dataset",
 					"fieldKey": ""
 				},
 				"links": {
-					"self": "/chronograf/v1/dashboards/5/templates/2d2d36ce-21ef-48fc-a0c1-4b954512f9a5"
+					"self": "/chronograf/v1/dashboards/2/templates/2d2d36ce-21ef-48fc-a0c1-4b954512f9a5"
+				}
+			},
+			{
+				"tempVar": ":Filter:",
+				"values": [
+					{
+						"value": "HSC-R",
+						"type": "influxql",
+						"selected": true
+					}
+				],
+				"id": "131eec04-5636-4950-bb73-2a381588315c",
+				"type": "influxql",
+				"label": "",
+				"query": {
+					"influxql": "SHOW TAG VALUES ON \"squash-prod\" FROM validate_drp WITH KEY = \"filter_name\" WHERE \"ci_dataset\" = :Dataset:",
+					"measurement": "",
+					"tagKey": "",
+					"fieldKey": ""
+				},
+				"links": {
+					"self": "/chronograf/v1/dashboards/2/templates/131eec04-5636-4950-bb73-2a381588315c"
 				}
 			}
 		],
-		"name": "validate_drp",
+		"name": "Data Release Processing metrics",
 		"organization": "default",
 		"links": {
-			"self": "/chronograf/v1/dashboards/5",
-			"cells": "/chronograf/v1/dashboards/5/cells",
-			"templates": "/chronograf/v1/dashboards/5/templates"
+			"self": "/chronograf/v1/dashboards/2",
+			"cells": "/chronograf/v1/dashboards/2/cells",
+			"templates": "/chronograf/v1/dashboards/2/templates"
 		}
 	}
 }

--- a/example/example_http_api.ipynb
+++ b/example/example_http_api.ipynb
@@ -8,16 +8,16 @@
     "\n",
     "In this example notebook we will sync the SQuaSH production data with our InfluxDB instance, so that we can visualize SQuaSH metrics using [Chronograf](https://chronograf-demo.lsst.codes/). See also [this notebook](https://github.com/lsst-sqre/influx-demo) for a quick introduction on InfluxDB concepts.\n",
     "\n",
-    "We are using the [InfluxDB HTTP API](https://docs.influxdata.com/influxdb/v1.6/tools/api/) for sending the data. The [InfluxDB python client](https://github.com/influxdata/influxdb-python) would also be an option."
+    "We are using the [InfluxDB HTTP API](https://docs.influxdata.com/influxdb/v1.6/tools/api/) and Python `requests` module for sending data. The [InfluxDB python client](https://github.com/influxdata/influxdb-python) could also be an option."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "SQUASH_API_URL = \"https://squash-restful-api.lsst.codes/\"\n",
+    "SQUASH_API_URL = \"https://squash-restful-api-demo.lsst.codes/\"\n",
     "INFLUXDB_API_URL = \"https://influxdb-demo.lsst.codes\""
    ]
   },
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start by creating a new database. Note that if the database already exists nothing is done (the existing data is preserved), and an status code 200 (OK) is returned."
+    "We start by creating a new database. Note that if the database already exists nothing is done, the existing data is preserved, and an status code 200 (OK) is returned."
    ]
   },
   {
@@ -37,7 +37,7 @@
     "import requests\n",
     "import json\n",
     "\n",
-    "DB = \"squash-prod\"\n",
+    "DB = \"squash-sandbox\"\n",
     "\n",
     "params={'q': 'CREATE DATABASE \"{}\"'.format(DB)}\n",
     "r = requests.post(url=INFLUXDB_API_URL + \"/query\", params=params)\n",
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we get a list of existing verification jobs from the SQuaSH API."
+    "Here we get a list of the existing verification jobs from the SQuaSH API."
    ]
   },
   {
@@ -65,12 +65,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following cell will actually grab the SQuaSH data and write it in the format used by InfluxDB (called [line protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/)):\n",
+    "Data in influxDb is organized as \"time series\". Each time series has points, one for each discrete sample of the metric. Points consist of:\n",
     "\n",
+    "* timestamp\n",
+    "* measurement : which conceptually matches the idea of a table in a relational database\n",
+    "* tags : key-value pairs in order to store index values, usually metadata.\n",
+    "* fields : key-value pairs, containing the value itself, non indexed.\n",
+    "\n",
+    "null values aren’t stored. The structure is of the data is:\n",
     "\n",
     "```#<measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]```\n",
     "\n",
-    "the important thing here is that a mesurement is equivalent to a \"table\" in the database, tags are annotations that are used to query the data, and thus are indexed. Fields correspond to the actual values, and the timestamp acts like the \"primary key\" in a time series database.\n",
+    "\n",
+    "The following cell will grab data from the SQuaSH API, and write it in that format, also known as [line protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/)):\n",
     "\n",
     "As you run this notebook you might follow the data ingestion using the [Data Explorer](https://chronograf-demo.lsst.codes/sources/2/chronograf/data-explorer) tool in Chronograf."
    ]
@@ -90,7 +97,7 @@
     "params = {'db': DB}\n",
     "\n",
     "for job_id in jobs['ids']:\n",
-    "    \n",
+    "\n",
     "    r = requests.get(SQUASH_API_URL + \"/job/{}\".format(job_id)).json()\n",
     "\n",
     "    # Skip datasets we don't want \n",
@@ -99,32 +106,55 @@
     "\n",
     "    print('Sending line for job {}...'.format(job_id))\n",
     "\n",
+    "    # The datamodel for SQuaSH in InfluxDB maps each verification package to \n",
+    "    # a different InfluxDB measurement, all job metadata to InfluxDB tags and \n",
+    "    # all metrics to fields.\n",
+    "    \n",
+    "    # Here we basically put the fields on their corresponding measurements.\n",
+    "    \n",
+    "    fields = {}\n",
     "    for meas in r['measurements']:\n",
+    "        \n",
+    "        # parse the verification package, eventually it could figure out as \n",
+    "        # another field in the SQuaSH API /measurements\n",
+    "        \n",
+    "        influxdb_measurement = meas['metric'].split('.')[0]\n",
+    "        \n",
+    "        if influxdb_measurement not in fields:\n",
+    "            fields[influxdb_measurement] = []\n",
+    "        fields[influxdb_measurement].append(\"{}={}\".format(meas['metric'], meas['value']))\n",
+    "        \n",
+    "    tags = []\n",
+    "    # skip package info for now \n",
+    "    del r['meta']['packages']\n",
+    "   \n",
+    "    # add ci_dataset as metadata\n",
+    "    r['meta']['dataset'] = r['ci_dataset']\n",
+    "     \n",
+    "    # delete rest of the env info for now\n",
+    "    del r['meta']['env']\n",
+    "    \n",
+    "    for key, value in r['meta'].items():\n",
+    "    \n",
+    "        # tag values cannot have blank spaces\n",
+    "        if type(value) == str:\n",
+    "            value = value.replace(\" \", \"_\")\n",
+    "            tags.append(\"{}=\\\"{}\\\"\".format(key, value))\n",
+    "        else:\n",
+    "            tags.append(\"{}={}\".format(key, value))\n",
     "\n",
-    "        measurement = meas['metric'].split('.')[0]\n",
+    "    timestamp = int((parse(r['date_created']) - EPOCH).total_seconds()*1e9)\n",
     "\n",
-    "        # a tag value cannot have space in them\n",
-    "        tags =  \"filter_name={},dataset={}\".format(r['meta']['filter_name'], r['ci_dataset'].replace(\" \", \"_\"))\n",
+    "    # create an InlfuxDB line for each measurement and send \n",
+    "    for measurement in fields.keys():\n",
+    "    \n",
+    "        line = \"{},{} {} {}\".format(measurement, \",\".join(tags), \",\".join(fields[measurement]), timestamp)\n",
     "\n",
-    "        fields = \"{}={}\".format(meas['metric'], meas['value'])\n",
-    "\n",
-    "        timestamp = int((parse(r['date_created']) - EPOCH).total_seconds()*1e9)\n",
-    "\n",
-    "        line = \"{},{} {} {}\".format(measurement, tags, fields, timestamp)\n",
-    "\n",
-    "        print(line)\n",
     "        post = requests.post(url=INFLUXDB_API_URL + \"/write\", params=params, data=line)\n",
     "\n",
     "        print(post.status_code)\n",
     "        print(post.text)\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Implement a "proof of concept dashboard" for `validate_drp` in Chronograf

- Display multiple time series plot
- Use the query builder to define the time series we want to display
- Combine more than one time series in a single plot (e.g. querying different databases)
- Use template variables to select a given property and make an interactive plot e.g. the dataset.
- Use static legend when grouping results by filter_name
- Test the export to (import from) JSON functionality
- Test the share functionality
- Use annotations on time series
- Use annotations on cells (available in Chronograf 1.7)
- Test Markdown/HTML content in cells (available in Chronograf 1.7)
- Keep a copy of the Dashboard on GitHub for version control