### PR TITLE
[DM-16484] Updated Chronograf version to 1.7.2  

### DIFF
--- a/chronograf-values.yaml
+++ b/chronograf-values.yaml
@@ -1,7 +1,7 @@
 ## Image Settings
 ##
 image:
-  repository: "docker.io/chronograf"
+  repository: "quay.io/influxdb/chronograf"
   tag: "latest"
   pullPolicy: "Always"
 


### PR DESCRIPTION
- Using quay.io/influxdb/chronograf:latest 

